### PR TITLE
Logic error

### DIFF
--- a/index.js
+++ b/index.js
@@ -69,7 +69,8 @@ function findTasksThatNeedUpdating(newHistory, oldHistory) {
   _.forEach(newHistory.tasks, function(item) {
     var old = oldHistory.tasks[item.todoist.id];
     if(!old || !old.todoist || old.todoist.content != item.todoist.content ||
-       old.todoist.checked != item.todoist.checked) {
+       old.todoist.checked != item.todoist.checked ||
+       old.todoist.due_date_utc != item.todoist.due_date_utc) {
       needToUpdate.push(item);
     }
   });


### PR DESCRIPTION
I was noticing that my completed todos weren't be synced until the second time I ran the command. I believe it's an error in the logic at line 71 where it checks if the task should be updated by checking various things, including:

```
!old.todoist.checked != item.todoist.checked
```

So, it says if the opposite of the checked status for the old version of the task does not equal the checked status of the new version, then go ahead and update it. So if the old version is not checked, and the version is, that results in:

```
!false != true
or
true != true
```

Which equals false, so it doesn't update the event. The next time of course, the old event will have become true, even though Habit never got updated, resulting in the check being:

```
!true != true
or
false != true
```

and so it does update.
### I could be wrong

If there's a reason for doing it the way you've written it, please let me know. But I think this will fix it. I also threw in some logic to update when the due date changes.
