### PR TITLE
Dailies won't uncheck themselves when an unrelated attribute is edited on Todoist

### DIFF
--- a/habitSync.js
+++ b/habitSync.js
@@ -185,6 +185,8 @@ habitSync.prototype.syncItemsToHabitRpg = function(items, cb) {
               var direction = true;
               task.completed = true;
               habit.updateTaskScore(item.habitrpg.id, direction, function(response, error){ });
+            } else if(item.habitrpg.completed) {
+              task.completed = true;
             }
           }
           habit.updateTask(item.habitrpg.id, task, function(err, res) {


### PR DESCRIPTION
Closes #21 
